### PR TITLE
Fix package version numbering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,11 @@ All notable changes to this project will be documented in this file.
 
 This project adheres to [Semantic Versioning](http://semver.org/).
 
-## [1.0.0a1]
+## [Unreleased]
+### Fixed
+- Package version reported correctly when utilised within foreign SCM (from @justjasongreen)
+
+## [1.0.0a1] - 2016-07-21
 ### Added
 - Scrape a list of meets occurring on a given date (from @justjasongreen)
 - Scrape a list of races occurring at a given meet (from @justjasongreen)
@@ -19,5 +23,6 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Create Python package (from @justjasongreen)
 - Implement DevOps support (from @justjasongreen)
 
+[Unreleased]: https://github.com/justjasongreen/punters_client/compare/1.0.0a1...HEAD
 [1.0.0a1]: https://github.com/justjasongreen/punters_client/compare/1.0.0a0...1.0.0a1
 [1.0.0a0]: https://github.com/justjasongreen/punters_client/tree/1.0.0a0

--- a/punters_client/__init__.py
+++ b/punters_client/__init__.py
@@ -1,5 +1,4 @@
-from setuptools_scm import get_version
-__version__ = get_version()
+__version__ = '1.0.0a1'
 
 
 from .scraper import Scraper

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,27 @@
 [bdist_wheel]
 universal=1
 
+[bumpversion]
+current_version = 1.0.0a1
+parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)((?P<pre>[ab]|rc)(?P<release>\d+))?
+serialize =
+    {major}.{minor}.{patch}{pre}{release}
+    {major}.{minor}.{patch}
+
+[bumpversion:file:punters_client/__init__.py]
+
+[bumpversion:file:tests/test_punters_client.py]
+
+[bumpversion:file:setup.py]
+
+[bumpversion:part:pre]
+optional_value = production
+values =
+    a
+    b
+    rc
+    production
+
 [pytest]
 addopts = --cov=punters_client --cov-report=term-missing --flake8 tests/
 flake8-ignore =

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ with open(path.join(here, 'README.rst'), encoding='utf-8') as f:
 
 setup(
     name='punters_client',
-    use_scm_version=True,
+    version='1.0.0a1',
     description='Python client library for www.punters.com.au',
     long_description=long_description,
     keywords='client library punters',
@@ -32,17 +32,15 @@ setup(
     license='MIT',
 
     packages=find_packages(exclude=['tests']),
-    setup_requires=[
-        'setuptools_scm'
-    ],
+    setup_requires=[],
     install_requires=[
         'cssselect',
         'pytz',
-        'setuptools_scm',
         'tzlocal'
     ],
     extras_require={
         'dev':  [
+            'bumpversion',
             'check-manifest'
         ],
         'test': [

--- a/tests/test_punters_client.py
+++ b/tests/test_punters_client.py
@@ -1,8 +1,7 @@
 import punters_client
-import setuptools_scm
 
 
 def test_version():
     """punters_client.__version__ should return the correct version string"""
 
-    assert punters_client.__version__ == setuptools_scm.get_version()
+    assert punters_client.__version__ == '1.0.0a1'


### PR DESCRIPTION
Fix the package version numbering issue by moving away from setuptools_scm automated versioning, and maintaining hard-coded version numbers within the source via the bumpversion tool instead.

(fixes #23)
