### PR TITLE
Increase Concurrent HTTP Requests Limit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 
+## [Unreleased]
+
+### Changed
+
+- Increase concurrent HTTP requests limit to CPU count x 5 (from @justjasongreen)
+
+
 ## [1.0.0b1] - 2016-07-23
 
 ### Changed
@@ -67,6 +74,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Implement DevOps support (from @justjasongreen)
 
 
+[Unreleased]: https://github.com/justjasongreen/punters_client/compare/1.0.0b1...HEAD
 [1.0.0b1]: https://github.com/justjasongreen/punters_client/compare/1.0.0a4...1.0.0b1
 [1.0.0a4]: https://github.com/justjasongreen/punters_client/compare/1.0.0a3...1.0.0a4
 [1.0.0a3]: https://github.com/justjasongreen/punters_client/compare/1.0.0a2...1.0.0a3

--- a/punters_client/scraper.py
+++ b/punters_client/scraper.py
@@ -29,7 +29,7 @@ class Scraper:
 
     URL_ROOT = 'https://www.punters.com.au/'
 
-    def __init__(self, http_client, html_parser, local_timezone=tzlocal.get_localzone(), concurrent_requests=multiprocessing.cpu_count()):
+    def __init__(self, http_client, html_parser, local_timezone=tzlocal.get_localzone(), concurrent_requests=multiprocessing.cpu_count() * 5):
 
         self.http_client = http_client
         self.parse_html = html_parser


### PR DESCRIPTION
Increase the default concurrent HTTP requests limit to CPU count x 5.

(closes #36)
