### PR TITLE
Check HTTP Status Codes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 
+## [Unreleased]
+
+### Changed
+
+- The Scraper.get_html will return None for HTTP 4xx errors (from @justjasongreen)
+
+
 ## [1.0.0b2] - 2016-07-24
 
 ### Changed
@@ -78,6 +85,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Implement DevOps support (from @justjasongreen)
 
 
+[Unreleased]: https://github.com/justjasongreen/punters_client/compare/1.0.0b2...HEAD
 [1.0.0b2]: https://github.com/justjasongreen/punters_client/compare/1.0.0b1...1.0.0b2
 [1.0.0b1]: https://github.com/justjasongreen/punters_client/compare/1.0.0a4...1.0.0b1
 [1.0.0a4]: https://github.com/justjasongreen/punters_client/compare/1.0.0a3...1.0.0a4

--- a/punters_client/scraper.py
+++ b/punters_client/scraper.py
@@ -56,9 +56,15 @@ class Scraper:
         try:
 
             with self.request_lock:
+
                 response = self.http_client.get(url)
-                response.raise_for_status()
-                return self.parse_html(response.text)
+                
+                if response.status_code >= 500:
+                    response.raise_for_status()
+                elif response.status_code >= 400:
+                    return None
+                else:
+                    return self.parse_html(response.text)
 
         except BaseException:
 

--- a/tests/scraper/get_html_test.py
+++ b/tests/scraper/get_html_test.py
@@ -1,8 +1,14 @@
 import pytest
 
 
-def test_raises(scraper):
-    """The get_html method should raise an exception when receiving a HTTP error status code"""
+def test_4xx(scraper):
+    """The get_html method should return None when receiving a HTTP 4xx status code"""
+
+    assert scraper.get_html('http://httpstat.us/404') is None
+
+
+def test_5xx(scraper):
+    """The get_html method should raise an exception when receiving a HTTP 5xx status code"""
 
     with pytest.raises(BaseException):
         scraper.get_html('http://httpstat.us/500')


### PR DESCRIPTION
Update the Scraper.get_html method to respond more appropriately to different HTTP status codes: raise an exception for 5xx, return None for 4xx, otherwise return the root HTML element.

(closes #39)
